### PR TITLE
QnA게시물 삭제 로직 수정(컨트롤러, 서비스, BoardDelDto추가)

### DIFF
--- a/Server/src/main/java/org/example/server/controller/BoardController.java
+++ b/Server/src/main/java/org/example/server/controller/BoardController.java
@@ -8,6 +8,7 @@ import org.example.server.adapter.LocalTimeTypeAdapter;
 import org.example.server.consts.MessageTypeConst;
 import org.example.server.dto.RequestData;
 import org.example.server.dto.ResponseData;
+import org.example.server.dto.board_dto.BoardDelDto;
 import org.example.server.dto.board_dto.BoardSaveDto;
 import org.example.server.dto.board_dto.BoardUpdateDto;
 import org.example.server.service.BoardService;
@@ -93,14 +94,11 @@ public class BoardController implements Controller {
                 // 데이터 타입 확인 로그 추가
                 System.out.println("데이터 타입: " + requestData.getData().getClass().getName());
 
-                if (requestData.getData() instanceof Double) {
+                if (requestData.getData() instanceof LinkedTreeMap) {
+                    LinkedTreeMap<?, ?> map = (LinkedTreeMap<?, ?>) requestData.getData();
+                    BoardDelDto boardDelDto = gson.fromJson(gson.toJson(map), BoardDelDto.class);
                     // Double을 Long으로 변환
-                    Double removeBoardNumDouble = (Double) requestData.getData();
-                    Long removeBoardNum = removeBoardNumDouble.longValue(); // Long으로 변환
-                    result = boardService.removeBoard(removeBoardNum);
-                } else if (requestData.getData() instanceof Long) {
-                    Long removeBoardNum = (Long) requestData.getData();
-                    result = boardService.removeBoard(removeBoardNum);
+                    result = boardService.removeBoard(boardDelDto);
                 } else {
                     result = new ResponseData("잘못된 데이터 타입", null);
                     // 예외 처리 또는 로깅

--- a/Server/src/main/java/org/example/server/dto/board_dto/BoardDelDto.java
+++ b/Server/src/main/java/org/example/server/dto/board_dto/BoardDelDto.java
@@ -1,0 +1,41 @@
+package org.example.server.dto.board_dto;
+
+import org.example.server.domain.board.Board;
+import org.example.server.domain.user.User;
+
+public class BoardDelDto {
+    private Board board; //게시물정보
+    private User user; //유저정보
+
+    private BoardDelDto(BoardDelDto.Builder builder) {
+        this.board = builder.board; // 빌더의 Board 필드로 초기화
+        this.user = builder.user;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public Board getBoard() {
+        return board;
+    }
+
+    public static class Builder {
+        private Board board; // Board 타입으로 수정
+        private User user;
+
+        public BoardDelDto.Builder user(User user) {
+            this.user = user;
+            return this;
+        }
+
+        public BoardDelDto.Builder board(Board board) {
+            this.board = board;
+            return this;
+        }
+
+        public BoardDelDto build() {
+            return new BoardDelDto(this);
+        }
+    }
+}


### PR DESCRIPTION
BoardDelDto 라는 dto를 추가하여 User와 Board를 담고있음.

프론트에서 해당 dto정보를 받아오면 User의 정보가 Board의 Usernum과 일치하는지, 또는 Role이 관리자인지 판단하기 위함. 해당 조건을 만족하면 boardNum값만 보내서 기존 Repository의 로직을 수행하면 끝.